### PR TITLE
fix attribute returning nil while it should be false

### DIFF
--- a/lib/strapi/content_type.rb
+++ b/lib/strapi/content_type.rb
@@ -61,7 +61,7 @@ module Strapi
     end
 
     def strapi_attr_value(attr, options)
-      return unless (value = @attributes[attr])
+      return if (value = @attributes[attr]).nil?
       return value unless (content_type = options[:content_type])
 
       content_type_class = content_type.is_a?(String) ? content_type.constantize : content_type

--- a/test/content_type_test.rb
+++ b/test/content_type_test.rb
@@ -12,6 +12,10 @@ end
 class Cow < Strapi::ContentType
   plural_id 'cows'
   field :name
+  field :is_sick
+  field :last_known_disease
+  field :age
+  field :weight_in_kilogram
   field :photo, content_type: Strapi::Media
   field :farm, content_type: 'Farm'
 end
@@ -99,5 +103,14 @@ class ContentTypeTest < Minitest::Test
     assert_equal cow.photo.url, 'http://localhost:1337/uploads/cow_8fdf0d4e0a.png'
     cow = Cow.find(2)
     assert_equal cow.photo.url, 'https://res.cloudinary.com/uploads/cow_8fdf0d4e0a.png'
+  end
+
+  def test_it_return_field_type_correctly
+    cow = Cow.find(1)
+    assert_equal cow.name, 'Hershey'
+    assert_equal cow.is_sick, false
+    assert_nil cow.last_known_disease
+    assert_equal cow.age, 4
+    assert_equal cow.weight_in_kilogram, 456.7
   end
 end

--- a/test/fixtures/cow.json
+++ b/test/fixtures/cow.json
@@ -3,6 +3,10 @@
     "id": 1,
     "attributes": {
       "name": "Hershey",
+      "isSick": false,
+      "lastKnownDisease": null,
+      "age": 4,
+      "weightInKilogram": 456.7,
       "createdAt": "2022-01-02T20:14:53.383Z",
       "updatedAt": "2022-01-02T20:14:55.291Z",
       "publishedAt": "2022-01-02T20:14:55.290Z",

--- a/test/fixtures/cow2.json
+++ b/test/fixtures/cow2.json
@@ -3,6 +3,10 @@
     "id": 1,
     "attributes": {
       "name": "Milky",
+      "isSick": false,
+      "lastKnownDisease": null,
+      "age": 1,
+      "weightInKilogram": 123.4,
       "createdAt": "2022-01-02T20:14:53.383Z",
       "updatedAt": "2022-01-02T20:14:55.291Z",
       "publishedAt": "2022-01-02T20:14:55.290Z",

--- a/test/fixtures/cows.json
+++ b/test/fixtures/cows.json
@@ -4,6 +4,7 @@
       "id": 1,
       "attributes": {
         "name": "Hershey",
+        "isSick": false,
         "createdAt": "2022-01-02T20:14:53.383Z",
         "updatedAt": "2022-01-02T20:14:55.291Z",
         "publishedAt": "2022-01-02T20:14:55.290Z",


### PR DESCRIPTION
Hey there, thank you for this gems. it's really help jumpstart our project that is using Strapi 4.

I found that if the field value is `false`, then it became `nil`.  Did some check, and it is because of this line

```ruby
def strapi_attr_value(attr, options)
  return unless (value = @attributes[attr])
  ...
end
```
if value is `false`, then it will return `nil`
